### PR TITLE
Delete entries from the cache after PUT/POST/DELETE requests.

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -42,6 +42,8 @@ module Faraday
 
     UNSAFE_METHODS = [:post, :put, :delete, :patch]
 
+    ERROR_STATUSES = 400..499
+
     # Public: Initializes a new HttpCache middleware.
     #
     # app  - the next endpoint on the 'Faraday' stack.
@@ -113,7 +115,7 @@ module Faraday
       end
 
       response.on_complete do
-        delete(@request) if should_delete?(@request[:method])
+        delete(@request) if should_delete?(response.status, @request[:method])
         log_request
       end
     end
@@ -210,8 +212,8 @@ module Faraday
     # cache entries for the same resource.
     #
     # Returns true or false.
-    def should_delete?(method)
-      UNSAFE_METHODS.include?(method)
+    def should_delete?(status, method)
+      UNSAFE_METHODS.include?(method) && !ERROR_STATUSES.cover?(status)
     end
 
     # Internal: Tries to locate a valid response or forwards the call to the stack.

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -111,6 +111,7 @@ module Faraday
       end
 
       response.on_complete do
+        delete(@request) if should_delete?(@request[:method])
         log_request
       end
     end
@@ -203,6 +204,14 @@ module Faraday
       method == :get || method == :head
     end
 
+    # Internal: Checks if the current request method should remove any existing
+    # cache entries for the same resource.
+    #
+    # Returns true or false.
+    def should_delete?(method)
+      method == :put || method == :delete || method == :post
+    end
+
     # Internal: Tries to locate a valid response or forwards the call to the stack.
     # * If no entry is present on the storage, the 'fetch' method will forward
     # the call to the remaining stack and return the new response.
@@ -282,6 +291,12 @@ module Faraday
       else
         trace :invalid
       end
+    end
+
+    def delete(request)
+      @storage.delete(request.merge(method: :get))
+      @storage.delete(request.merge(method: :head))
+      trace :delete
     end
 
     # Internal: Fetches the response from the Faraday stack and stores it.

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -40,6 +40,8 @@ module Faraday
     # Internal: valid options for the 'initialize' configuration Hash.
     VALID_OPTIONS = [:store, :serializer, :logger, :store_options, :shared_cache]
 
+    UNSAFE_METHODS = [:post, :put, :delete, :patch]
+
     # Public: Initializes a new HttpCache middleware.
     #
     # app  - the next endpoint on the 'Faraday' stack.
@@ -209,7 +211,7 @@ module Faraday
     #
     # Returns true or false.
     def should_delete?(method)
-      method == :put || method == :delete || method == :post
+      UNSAFE_METHODS.include?(method)
     end
 
     # Internal: Tries to locate a valid response or forwards the call to the stack.

--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -77,6 +77,15 @@ module Faraday
         end
       end
 
+      # Public: Deletes a response from the cache, when the cached response is
+      # outdated.
+      #
+      # Returns nothing.
+      def delete(request)
+        key = cache_key_for(request)
+        cache.delete(key)
+      end
+
       private
 
       # Internal: Generates a String key for a given request object.
@@ -143,6 +152,10 @@ module Faraday
 
       def write(key, value)
         @cache[key] = value
+      end
+
+      def delete(key)
+        @cache.delete(key)
       end
     end
   end

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -43,6 +43,12 @@ describe Faraday::HttpCache do
     client.post('counter')
   end
 
+  it 'does not expires POST requests that failed' do
+    client.get('get')
+    client.post('get')
+    expect(client.get('get').body).to eq('1')
+  end
+
   it 'expires PUT requests' do
     client.get('counter')
     client.put('counter')

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -23,13 +23,46 @@ describe Faraday::HttpCache do
   end
 
   it 'logs that a POST request is unacceptable' do
-    expect(logger).to receive(:debug).with('HTTP Cache: [POST /post] unacceptable')
+    expect(logger).to receive(:debug).with('HTTP Cache: [POST /post] unacceptable, delete')
     client.post('post').body
   end
 
   it 'does not cache responses with invalid status code' do
     client.get('broken')
     expect(client.get('broken').body).to eq('2')
+  end
+
+  it 'expires POST requests' do
+    client.get('counter')
+    client.post('counter')
+    expect(client.get('counter').body).to eq('2')
+  end
+
+  it 'logs that a POST request was deleted from the cache' do
+    expect(logger).to receive(:debug).with('HTTP Cache: [POST /counter] unacceptable, delete')
+    client.post('counter')
+  end
+
+  it 'expires PUT requests' do
+    client.get('counter')
+    client.put('counter')
+    expect(client.get('counter').body).to eq('2')
+  end
+
+  it 'logs that a PUT request was deleted from the cache' do
+    expect(logger).to receive(:debug).with('HTTP Cache: [PUT /counter] unacceptable, delete')
+    client.put('counter')
+  end
+
+  it 'expires DELETE requests' do
+    client.get('counter')
+    client.delete('counter')
+    expect(client.get('counter').body).to eq('2')
+  end
+
+  it 'logs that a DELETE request was deleted from the cache' do
+    expect(logger).to receive(:debug).with('HTTP Cache: [DELETE /counter] unacceptable, delete')
+    client.delete('counter')
   end
 
   it 'logs that a response with a bad status code is invalid' do

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -65,6 +65,17 @@ describe Faraday::HttpCache do
     client.delete('counter')
   end
 
+  it 'expires PATCH requests' do
+    client.get('counter')
+    client.patch('counter')
+    expect(client.get('counter').body).to eq('2')
+  end
+
+  it 'logs that a PATCH request was deleted from the cache' do
+    expect(logger).to receive(:debug).with('HTTP Cache: [PATCH /counter] unacceptable, delete')
+    client.patch('counter')
+  end
+
   it 'logs that a response with a bad status code is invalid' do
     expect(logger).to receive(:debug).with('HTTP Cache: [GET /broken] miss, invalid')
     client.get('broken')

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -39,7 +39,6 @@ describe Faraday::HttpCache::Storage do
   end
 
   describe 'storing responses' do
-
     shared_examples 'serialization' do
       it 'writes the response json to the underlying cache using a digest as the key' do
         expect(cache).to receive(:write).with(cache_key, serialized)
@@ -101,6 +100,17 @@ describe Faraday::HttpCache::Storage do
     end
   end
 
+  describe 'deleting responses' do
+    it 'removes the response from the cache' do
+      request = { method: :get, request_headers: {}, url: URI.parse('http://foo.bar/path/to/somewhere') }
+      response = Faraday::HttpCache::Response.new(status: 200, body: 'body')
+
+      cache.write(request, response)
+      cache.delete(request)
+      expect(cache.read(request)).to be_nil
+    end
+  end
+
   describe 'remove age before caching and normalize max-age if non-zero age present' do
     it 'is fresh if the response still has some time to live' do
       headers = {
@@ -134,5 +144,4 @@ describe Faraday::HttpCache::Storage do
       expect(cached_response).not_to be_fresh
     end
   end
-
 end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -53,6 +53,9 @@ class TestApp < Sinatra::Base
   delete '/counter' do
   end
 
+  patch '/counter' do
+  end
+
   get '/get' do
     [200, { 'Cache-Control' => 'max-age=200' }, increment_counter]
   end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -40,6 +40,19 @@ class TestApp < Sinatra::Base
     [500, { 'Cache-Control' => 'max-age=400' }, increment_counter]
   end
 
+  get '/counter' do
+    [200, { 'Cache-Control' => 'max-age=200' }, increment_counter]
+  end
+
+  post '/counter' do
+  end
+
+  put '/counter' do
+  end
+
+  delete '/counter' do
+  end
+
   get '/get' do
     [200, { 'Cache-Control' => 'max-age=200' }, increment_counter]
   end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -60,6 +60,10 @@ class TestApp < Sinatra::Base
     [200, { 'Cache-Control' => 'max-age=200' }, increment_counter]
   end
 
+  post '/get' do
+    halt 405
+  end
+
   get '/private' do
     [200, { 'Cache-Control' => 'private, max-age=100' }, increment_counter]
   end


### PR DESCRIPTION
A first stab on #42.

Some things that need to polishing:

* [ ] Log messages aren't helpful. Right now every request will be logged with `unacceptable, delete`. I'm not sure if we should check if the request was cached before to ensure that only real deletes gets logged as `delete`.
* [ ] As we cache both `GET` and `HEAD` differently, we need to try to delete both kind of requests in the same way. I'm not sure if this is the time to normalize that and treat all responses for a specific location the same.
* [ ] The RFC mentions that the cache must also purge entries based on the Location or Content-Location headers, so we might need to implement that.