### PR TITLE
Add partial support for request Cache-Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-version
 InstalledFiles
 _yardoc
 coverage

--- a/lib/faraday/http_cache/request.rb
+++ b/lib/faraday/http_cache/request.rb
@@ -1,0 +1,54 @@
+module Faraday
+  class HttpCache < Faraday::Middleware
+    # Internal: A class to represent a request
+    class Request
+
+      class << self
+        def from_env(env)
+          hash = env.to_hash
+          new(method: hash[:method], url: hash[:url], headers: hash[:request_headers].dup)
+        end
+      end
+
+      attr_reader :method, :url, :headers
+
+      def initialize(options)
+        @method, @url, @headers = options[:method], options[:url], options[:headers]
+      end
+
+      # Internal: Validates if the current request method is valid for caching.
+      #
+      # Returns true if the method is ':get' or ':head'.
+      def cacheable?
+        return false if method != :get && method != :head
+        return false if cache_control.no_store?
+        true
+      end
+
+      def no_cache?
+        cache_control.no_cache?
+      end
+
+      # Internal: Gets the 'CacheControl' object.
+      def cache_control
+        @cache_control ||= CacheControl.new(headers['Cache-Control'])
+      end
+
+      def cache_key
+        digest = Digest::SHA1.new
+        digest.update 'method'
+        digest.update method.to_s
+        digest.update 'request_headers'
+        headers.keys.sort.each do |key|
+          digest.update key.to_s
+          digest.update headers[key].to_s
+        end
+        digest.update 'url'
+        digest.update url.to_s
+
+        digest.to_s
+      end
+
+    end
+  end
+end

--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -47,7 +47,7 @@ module Faraday
       #           :request_headers - The custom headers for the request.
       # response - The Faraday::HttpCache::Response instance to be stored.
       def write(request, response)
-        key = cache_key_for(request)
+        key = request.cache_key
         value = @serializer.dump(response.serializable_hash)
         cache.write(key, value)
       rescue Encoding::UndefinedConversionError => e
@@ -65,7 +65,7 @@ module Faraday
       #           :request_headers - The custom headers for the request.
       # klass - The Class to be instantiated with the recovered informations.
       def read(request, klass = Faraday::HttpCache::Response)
-        cache_key = cache_key_for(request)
+        cache_key = request.cache_key
         found = cache.read(cache_key)
 
         if found
@@ -78,24 +78,6 @@ module Faraday
       end
 
       private
-
-      # Internal: Generates a String key for a given request object.
-      #
-      # Returns the digested String.
-      def cache_key_for(request)
-        digest = Digest::SHA1.new
-        digest.update 'method'
-        digest.update request[:method].to_s
-        digest.update 'request_headers'
-        request[:request_headers].keys.sort.each do |key|
-          digest.update key.to_s
-          digest.update request[:request_headers][key].to_s
-        end
-        digest.update 'url'
-        digest.update request[:url].to_s
-
-        digest.to_s
-      end
 
       # Internal: Creates a cache store from 'ActiveSupport' with a set of options.
       #

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -65,7 +65,7 @@ describe Faraday::HttpCache do
     end
   end
 
-  it 'does not cache requests with a explicit no-store directive' do
+  it 'does not cache responses with a explicit no-store directive' do
     client.get('dontstore')
     expect(client.get('dontstore').body).to eq('2')
   end
@@ -94,6 +94,19 @@ describe Faraday::HttpCache do
   it 'caches GET responses' do
     client.get('get')
     expect(client.get('get').body).to eq('1')
+  end
+
+  context 'when the request has a "no-cache" directive' do
+    it 'by-passes the cache' do
+      client.get('get', nil, 'Cache-Control' => 'no-cache')
+      expect(client.get('get', nil, 'Cache-Control' => 'no-cache').body).to eq('2')
+    end
+
+    it 'caches the response' do
+      pending 'not possible as long as we use all the request headers for the cache key'
+      client.get('get', nil, 'Cache-Control' => 'no-cache')
+      expect(client.get('get', nil).body).to eq('1')
+    end
   end
 
   it 'logs that a GET response is stored' do

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Faraday::HttpCache::Request do
+  subject { Faraday::HttpCache::Request.new method: method, url: url, headers: headers }
+  let(:method) { :get }
+  let(:url) { URI.parse('http://example.com/path/to/somewhere') }
+  let(:headers) { {} }
+
+  it { should respond_to(:cache_key)}
+
+  context 'a GET request' do
+    it { should be_cacheable }
+  end
+
+  context 'a HEAD request' do
+    let(:method) { :head }
+    it { should be_cacheable }
+  end
+
+  context 'a POST request' do
+    let(:method) { :post }
+    it { should_not be_cacheable }
+  end
+
+  context 'a PUT request' do
+    let(:method) { :put }
+    it { should_not be_cacheable }
+  end
+
+  context 'an OPTIONS request' do
+    let(:method) { :options }
+    it { should_not be_cacheable }
+  end
+
+  context 'a DELETE request' do
+    let(:method) { :delete }
+    it { should_not be_cacheable }
+  end
+
+  context 'a TRACE request' do
+    let(:method) { :trace }
+    it { should_not be_cacheable }
+  end
+
+  context 'with "Cache-Control: no-store"' do
+    let(:headers) { { 'Cache-Control' => 'no-store' } }
+    it { should_not be_cacheable }
+  end
+
+end

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 
 describe Faraday::HttpCache::Storage do
-  let(:request) do
-    { method: :get, request_headers: {}, url: URI.parse('http://foo.bar/') }
-  end
-
+  let(:cache_key) { '084dd517af7651a9ca7823728544b9b55e0cc130' }
+  let(:request) { double 'a Request', cache_key: cache_key }
   let(:response) { double(serializable_hash: {}) }
 
   let(:cache) { ActiveSupport::Cache.lookup_store }
@@ -73,13 +71,11 @@ describe Faraday::HttpCache::Storage do
     context 'with Marshal serializer' do
       let(:storage)    { Faraday::HttpCache::Storage.new store: cache, serializer: Marshal }
       let(:serialized) { Marshal.dump(response.serializable_hash) }
-      let(:cache_key) { '084dd517af7651a9ca7823728544b9b55e0cc130' }
+      let(:duplicate_request) { double 'another Request', cache_key: cache_key }
 
       it_behaves_like 'serialization'
 
       it 'should have a unique cache key' do
-        request = { method: :get, request_headers: {}, url: URI.parse('http://foo.bar/path/to/somewhere') }
-        duplicate_request = { method: :get, request_headers: {}, url: URI.parse('http://foo.bar/path/to/somewhere') }
         storage = Faraday::HttpCache::Storage.new(serializer: Marshal)
         response = Faraday::HttpCache::Response.new(status: 200, body: 'body')
         storage.write(request, response)


### PR DESCRIPTION
So far only no-cache and no-store are supported.

The spec states that a transparent cache MAY store the response
that has been fetched with the no-cache header. However, since all
request headers are taken into account when calculating the cache
key, this does not work in the current implementation.