### PR TITLE
Changing the cache key semantics.

### DIFF
--- a/lib/faraday/http_cache/request.rb
+++ b/lib/faraday/http_cache/request.rb
@@ -34,21 +34,13 @@ module Faraday
         @cache_control ||= CacheControl.new(headers['Cache-Control'])
       end
 
-      def cache_key
-        digest = Digest::SHA1.new
-        digest.update 'method'
-        digest.update method.to_s
-        digest.update 'request_headers'
-        headers.keys.sort.each do |key|
-          digest.update key.to_s
-          digest.update headers[key].to_s
-        end
-        digest.update 'url'
-        digest.update url.to_s
-
-        digest.to_s
+      def serializable_hash
+        {
+          method: @method,
+          url: @url,
+          headers: @headers
+        }
       end
-
     end
   end
 end

--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -131,8 +131,15 @@ module Faraday
         end
       end
 
+      # Internal: Computes the cache key for a specific request, taking in
+      # account the current serializer to avoid cross serialization issues.
+      #
+      # request - The Faraday::HttpCache::Request instance.
+      #
+      # Returns a String.
       def cache_key_for(request)
-        Digest::SHA1.hexdigest(request.url.to_s)
+        prefix = (@serializer.is_a?(Module) ? @serializer : @serializer.class).name
+        Digest::SHA1.hexdigest("#{prefix}#{request.url}")
       end
 
       # Internal: Creates a cache store from 'ActiveSupport' with a set of options.

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -75,11 +75,13 @@ describe Faraday::HttpCache do
     client.get('dontstore')
   end
 
-  it 'caches multiple responses when the headers differ' do
+  it 'does not caches multiple responses when the headers differ' do
     client.get('get', nil, 'HTTP_ACCEPT' => 'text/html')
     expect(client.get('get', nil, 'HTTP_ACCEPT' => 'text/html').body).to eq('1')
-    expect(client.get('get', nil, 'HTTP_ACCEPT' => 'application/json').body).to eq('2')
+    expect(client.get('get', nil, 'HTTP_ACCEPT' => 'application/json').body).to eq('1')
   end
+
+  it 'caches multiples responses based on the "Vary" header'
 
   it 'caches requests with the "Expires" header' do
     client.get('expires')
@@ -103,7 +105,6 @@ describe Faraday::HttpCache do
     end
 
     it 'caches the response' do
-      pending 'not possible as long as we use all the request headers for the cache key'
       client.get('get', nil, 'Cache-Control' => 'no-cache')
       expect(client.get('get', nil).body).to eq('1')
     end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -6,8 +6,6 @@ describe Faraday::HttpCache::Request do
   let(:url) { URI.parse('http://example.com/path/to/somewhere') }
   let(:headers) { {} }
 
-  it { should respond_to(:cache_key)}
-
   context 'a GET request' do
     it { should be_cacheable }
   end

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Faraday::HttpCache::Storage do
-  let(:cache_key) { 'bdde120549a0e4eaa55741ffb6de17faea5f88e9' }
+  let(:cache_key) { '6e3b941d0f7572291c777b3e48c04b74124a55d0' }
   let(:request) do
     env = { method: :get, url: 'http://test/index' }
     double(env.merge(serializable_hash: env))
@@ -72,6 +72,7 @@ describe Faraday::HttpCache::Storage do
     end
 
     context 'with the Marshal serializer' do
+      let(:cache_key) { '337d1e9c6c92423dd1c48a23054139058f97be40' }
       let(:serializer) { Marshal }
       let(:storage) { Faraday::HttpCache::Storage.new(store: cache, serializer: Marshal) }
 


### PR DESCRIPTION
I'm changing the structure of how we are caching responses so we can fully implement #53 and #48. Now our cache keys are just the request URI and we store multiple responses (and their requests) together. We then look for the most suitable response in the Array to return to the client (and this leaves a spot to implement the proper support for the `Vary` header).

One thing that I think of is to add the `@serializer` class to the cache key - this way different serializers won't reach the same cached objects.

This implementation is based on the data structure that rack-cache uses for the same purpose.