### PR TITLE
Add option to ignore certain headers when forming the cache key

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -39,17 +39,18 @@ module Faraday
   #   end
   class HttpCache < Faraday::Middleware
     # Internal: valid options for the 'initialize' configuration Hash.
-    VALID_OPTIONS = [:store, :serializer, :logger, :store_options, :shared_cache]
+    VALID_OPTIONS = [:store, :serializer, :logger, :store_options, :shared_cache, :ignore_headers]
 
     # Public: Initializes a new HttpCache middleware.
     #
     # app  - the next endpoint on the 'Faraday' stack.
     # args - aditional options to setup the logger and the storage.
-    #             :logger        - A logger object.
-    #             :serializer    - A serializer that should respond to 'dump' and 'load'.
-    #             :shared_cache  - A flag to mark the middleware as a shared cache or not.
-    #             :store         - A cache store that should respond to 'read' and 'write'.
-    #             :store_options - Deprecated: additional options to setup the cache store.
+    #             :logger         - A logger object.
+    #             :serializer     - A serializer that should respond to 'dump' and 'load'.
+    #             :shared_cache   - A flag to mark the middleware as a shared cache or not.
+    #             :store          - A cache store that should respond to 'read' and 'write'.
+    #             :store_options  - Deprecated: additional options to setup the cache store.
+    #             :ignore_headers - One or more headers to ignore when forming the cache key.
     #
     # Examples:
     #

--- a/lib/faraday/http_cache/request.rb
+++ b/lib/faraday/http_cache/request.rb
@@ -34,12 +34,16 @@ module Faraday
         @cache_control ||= CacheControl.new(headers['Cache-Control'])
       end
 
-      def cache_key
+      def cache_key(options = {})
+        ignore_headers = options.fetch(:ignore_headers, [])
+
         digest = Digest::SHA1.new
         digest.update 'method'
         digest.update method.to_s
         digest.update 'request_headers'
         headers.keys.sort.each do |key|
+          next if ignore_headers.include?(key)
+
           digest.update key.to_s
           digest.update headers[key].to_s
         end

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -75,10 +75,31 @@ describe Faraday::HttpCache do
     client.get('dontstore')
   end
 
-  it 'caches multiple responses when the headers differ' do
-    client.get('get', nil, 'HTTP_ACCEPT' => 'text/html')
-    expect(client.get('get', nil, 'HTTP_ACCEPT' => 'text/html').body).to eq('1')
-    expect(client.get('get', nil, 'HTTP_ACCEPT' => 'application/json').body).to eq('2')
+  describe 'headers' do
+    let(:headers_1) { {'HTTP_ACCEPT' => 'text/html'} }
+    let(:headers_2) { {'HTTP_ACCEPT' => 'application/json'} }
+
+    def get(headers)
+      client.get('get', nil, headers)
+    end
+
+    context 'not ignored' do
+      it 'caches multiple responses when the headers differ' do
+        get(headers_1)
+        expect(get(headers_1).body).to eq('1')
+        expect(get(headers_2).body).to eq('2')
+      end
+    end
+
+    context 'ignored' do
+      let(:options) { {ignore_headers: 'HTTP_ACCEPT'} }
+
+      it 'caches one response when the headers differ' do
+        get(headers_1)
+        expect(get(headers_1).body).to eq('1')
+        expect(get(headers_2).body).to eq('1')
+      end
+    end
   end
 
   it 'caches requests with the "Expires" header' do


### PR DESCRIPTION
This feature has been added to solve a particular integration problem, but it may be of general use. It's modeled after the `ignore_params` option in [`FaradayMiddleware::Caching`](http://git.io/3UbNfg).

By default, the [warden-hmac-authentication library](https://github.com/Asquera/warden-hmac-authentication) signs each request with `Authorization` and `Date` headers. The values of both of these fields change at least once a second. To keep the Faraday HTTP cache from needlessly expiring, we can now instruct it to ignore these particular headers, for example:

```ruby
faraday.use Faraday::HttpCache, store: Rails.cache, ignore_headers: %w(Authorization Date)
```

Thanks for your help!