### PR TITLE
Add support for the `Vary` header.

### DIFF
--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -110,7 +110,17 @@ module Faraday
       #
       # Returns true or false.
       def response_matches?(request, cached_request, cached_response)
-        request.method.to_s == cached_request[:method]
+        request.method.to_s == cached_request[:method] &&
+          vary_matches?(cached_response, request, cached_request)
+      end
+
+      def vary_matches?(cached_response, request, cached_request)
+        headers = Faraday::Utils::Headers.new(cached_response[:response_headers])
+        vary = headers['Vary'].to_s
+
+        vary.empty? || (vary != '*' && vary.split(/[\s,]+/).all? do |header|
+          request.headers[header] == cached_request[:headers][header]
+        end)
       end
 
       def serialize_entry(*objects)

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -145,7 +145,17 @@ describe Faraday::HttpCache do
     expect(client.get('get', nil, 'HTTP_ACCEPT' => 'application/json').body).to eq('1')
   end
 
-  it 'caches multiples responses based on the "Vary" header'
+  it 'caches multiples responses based on the "Vary" header' do
+    client.get('vary', nil, 'User-Agent' => 'Agent/1.0')
+    expect(client.get('vary', nil, 'User-Agent' => 'Agent/1.0').body).to eq('1')
+    expect(client.get('vary', nil, 'User-Agent' => 'Agent/2.0').body).to eq('2')
+    expect(client.get('vary', nil, 'User-Agent' => 'Agent/3.0').body).to eq('3')
+  end
+
+  it 'never caches responses with the wildcard "Vary" header' do
+    client.get('vary-wildcard')
+    expect(client.get('vary-wildcard').body).to eq('2')
+  end
 
   it 'caches requests with the "Expires" header' do
     client.get('expires')

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -7,7 +7,7 @@ describe Faraday::HttpCache::Storage do
     double(env.merge(serializable_hash: env))
   end
 
-  let(:response) { double(serializable_hash: {}) }
+  let(:response) { double(serializable_hash: { response_headers: {} }) }
 
   let(:cache) { Faraday::HttpCache::MemoryStore.new }
 

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -110,6 +110,14 @@ class TestApp < Sinatra::Base
     end
   end
 
+  get '/vary' do
+    [200, { 'Cache-Control' => 'max-age=50', 'Vary' => 'User-Agent' }, increment_counter]
+  end
+
+  get '/vary-wildcard' do
+    [200, { 'Cache-Control' => 'max-age=50', 'Vary' => '*' }, increment_counter]
+  end
+
   # Increments the 'requests' counter to act as a newly processed response.
   def increment_counter
     (settings.requests += 1).to_s


### PR DESCRIPTION
Now, we take in account the headers listed on the `Vary` header of a stored
response to see if the incoming request matches the previously cached request.