### PR TITLE
Compare string to string in response_matches?

### DIFF
--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -110,7 +110,7 @@ module Faraday
       #
       # Returns true or false.
       def response_matches?(request, cached_request, cached_response)
-        request.method.to_s == cached_request[:method] &&
+        request.method.to_s == cached_request[:method].to_s &&
           vary_matches?(cached_response, request, cached_request)
       end
 

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -70,14 +70,30 @@ describe Faraday::HttpCache::Storage do
   end
 
   describe 'reading responses' do
-    it 'returns nil if the response is not cached' do
-      expect(subject.read(request)).to be_nil
+    let(:storage) { Faraday::HttpCache::Storage.new(store: cache, serializer: serializer) }
+
+    shared_examples 'A storage with serialization' do
+      it 'returns nil if the response is not cached' do
+        expect(subject.read(request)).to be_nil
+      end
+
+      it 'decodes a stored response' do
+        subject.write(request, response)
+
+        expect(subject.read(request)).to be_a(Faraday::HttpCache::Response)
+      end
     end
 
-    it 'decodes a stored response' do
-      subject.write(request, response)
+    context 'with the JSON serializer' do
+      let(:serializer) { JSON }
 
-      expect(subject.read(request)).to be_a(Faraday::HttpCache::Response)
+      it_behaves_like 'A storage with serialization'
+    end
+
+    context 'with the Marshal serializer' do
+      let(:serializer) { Marshal }
+
+      it_behaves_like 'A storage with serialization'
     end
   end
 


### PR DESCRIPTION
When using the `Marshal` serializer, in `Faraday::HttpCache::Storage#response_matches?`, [a string `'get'` is not compared with a string `:get`](https://github.com/plataformatec/faraday-http-cache/blob/5050e081802916712ccb84504bf377daad26f89b/lib/faraday/http_cache/storage.rb#L113).