### PR TITLE
Strip out illegal headers from 304 responses

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -200,8 +200,16 @@ module Faraday
         response = Response.new(requested_env)
         if response.not_modified?
           trace :valid
+          updated_response_headers = response.payload[:response_headers]
+
+          # These headers are not allowed in 304 responses, yet some proxy
+          # servers add them in. Don't override the values from the original
+          # response.
+          updated_response_headers.delete('Content-Type')
+          updated_response_headers.delete('Content-Length')
+
           updated_payload = entry.payload
-          updated_payload[:response_headers].update(response.payload[:response_headers])
+          updated_payload[:response_headers].update(updated_response_headers)
           requested_env.update(updated_payload)
           response = Response.new(updated_payload)
         end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Faraday::HttpCache do
+  let(:backend) { Faraday::Adapter::Test::Stubs.new }
+
+  let(:client) do
+    Faraday.new(url: ENV['FARADAY_SERVER']) do |stack|
+      stack.use Faraday::HttpCache
+      stack.adapter :test, backend
+    end
+  end
+
+  it 'maintains the "Content-Type" header for cached responses' do
+    backend.get('/test') { [200, { 'ETag' => '123ABC', 'Content-Type' => 'x' }, ""] }
+    first_content_type = client.get('/test').headers['Content-Type']
+
+    # The Content-Type header of the validation response should be ignored.
+    backend.get('/test') { [304, { 'Content-Type' => 'y' }, ""] }
+    second_content_type = client.get('/test').headers['Content-Type']
+
+    expect(first_content_type).to eq('x')
+    expect(second_content_type).to eq('x')
+  end
+
+  it 'maintains the "Content-Length" header for cached responses' do
+    backend.get('/test') { [200, { 'ETag' => '123ABC', 'Content-Length' => 1 }, ""] }
+    first_content_length = client.get('/test').headers['Content-Length']
+
+    # The Content-Length header of the validation response should be ignored.
+    backend.get('/test') { [304, { 'Content-Length' => 2 }, ""] }
+    second_content_length = client.get('/test').headers['Content-Length']
+
+    expect(first_content_length).to eq(1)
+    expect(second_content_length).to eq(1)
+  end
+end


### PR DESCRIPTION
Some servers and proxies set the Content-Type and Content-Length headers when responding with status 304 even though these headers are not allowed for that status. Rather than overwrite the cached values of these headers, we simply ignore the ones from the 304.

It took me a *long* time to figure this one out, but the fix was rather simple in the end.