### PR TITLE
Include a trace of actions in the response env

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -118,6 +118,7 @@ module Faraday
       response.on_complete do
         delete(@request, response) if should_delete?(response.status, @request.method)
         log_request
+        response.env[:http_cache_trace] = @trace
       end
     end
 

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -32,6 +32,11 @@ describe Faraday::HttpCache do
     expect(client.get('broken').body).to eq('2')
   end
 
+  it 'adds a trace of the actions performed to the env' do
+    response = client.post('post')
+    expect(response.env[:http_cache_trace]).to eq([:unacceptable, :delete])
+  end
+
   describe 'cache invalidation' do
     it 'expires POST requests' do
       client.get('counter')


### PR DESCRIPTION
This change allows basic instrumentation of the middleware. The response env is updated with the trace, allowing some other middleware to figure out stuff like whether the cached response was fresh, valid, uncacheable, etc. 