### PR TITLE
Instrument Faraday::HttpCache

### DIFF
--- a/spec/instrumentation_spec.rb
+++ b/spec/instrumentation_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe "Instrumentation" do
+  let(:backend) { Faraday::Adapter::Test::Stubs.new }
+
+  let(:client) do
+    Faraday.new do |stack|
+      stack.use Faraday::HttpCache, instrumenter: ActiveSupport::Notifications
+      stack.adapter :test, backend
+    end
+  end
+
+  let(:events) { [] }
+  let(:subscriber) { lambda {|*args| events << ActiveSupport::Notifications::Event.new(*args) } }
+
+  around do |example|
+    ActiveSupport::Notifications.subscribed(subscriber, "process_request.http_cache.faraday") do
+      example.run
+    end
+  end
+
+  describe "the :cache_status payload entry" do
+    it "is :miss if there's no cache entry for the URL" do
+      backend.get("/hello") do
+        [200, { "Cache-Control" => "public, max-age=999" }, ""]
+      end
+
+      client.get("/hello")
+      expect(events.last.payload.fetch(:cache_status)).to eq(:miss)
+    end
+
+    it "is :fresh if the cache entry has not expired" do
+      backend.get("/hello") do
+        [200, { "Cache-Control" => "public, max-age=999" }, ""]
+      end
+
+      client.get("/hello") # miss
+      client.get("/hello") # fresh!
+      expect(events.last.payload.fetch(:cache_status)).to eq(:fresh)
+    end
+
+    it "is :valid if the cache entry can be validated against the upstream" do
+      backend.get("/hello") do
+        headers = {
+          "Cache-Control" => "public, must-revalidate, max-age=0",
+          "Etag" => "123ABCD"
+        }
+
+        [200, headers, ""]
+      end
+
+      client.get("/hello") # miss
+
+      backend.get("/hello") { [304, {}, ""] }
+
+      client.get("/hello") # valid!
+      expect(events.last.payload.fetch(:cache_status)).to eq(:valid)
+    end
+
+    it "is :invalid if the cache entry could not be validated against the upstream" do
+      backend.get("/hello") do
+        headers = {
+          "Cache-Control" => "public, must-revalidate, max-age=0",
+          "Etag" => "123ABCD"
+        }
+
+        [200, headers, ""]
+      end
+
+      client.get("/hello") # miss
+
+      backend.get("/hello") { [200, {}, ""] }
+
+      client.get("/hello") # invalid!
+      expect(events.last.payload.fetch(:cache_status)).to eq(:invalid)
+    end
+  end
+end


### PR DESCRIPTION
An event will be published to ActiveSupport::Notifications for each request that is processed. The event will in its payload have a key`:cache_status` that indicates whether the request already had a cached
response.

Things to consider:

- Currently, the event name is `process_request.http_cache.faraday`. Alternatives should be suggested before merging.
- Only a single event type is emitted, with an entry in the payload indicating the status of the cache processing.
- There are only four possible statuses, and it's not indicated whether the response is stored – I'm not sure whether that's needed or not.

A possible subscriber could be:

```ruby
statsd = Statsd.new

ActiveSupport::Notifications.subscribe "process_request.http_cache.faraday" do |*args|
  event = ActiveSupport::Notifications::Event.new(*args)
  cache_status = event.payload.fetch(:cache_status)

  case cache_status
  when :fresh, :valid
    statsd.increment("api-calls.cache_hits")
  when :invalid, :miss
    statsd.increment("api-calls.cache_misses")
  end
end
```