### PR TITLE
Duplicate frozen cache entries

### DIFF
--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -46,6 +46,7 @@ module Faraday
         entry = serialize_entry(request.serializable_hash, response.serializable_hash)
 
         entries = cache.read(key) || []
+        entries = entries.dup if entries.frozen?
 
         entries.reject! do |(cached_request, cached_response)|
           response_matches?(request, deserialize_object(cached_request), deserialize_object(cached_response))


### PR DESCRIPTION
:snowman: Under Rails 3.0 the cache entry can be frozen. Modifying that entry in place then causes an exception. 
:ambulance: To fix, we .dup any frozen entry.
:green_heart: All specs continue to pass. I didn't add a new test as there was no obvious way to do so. We have tested this locally on our setup and it works for us.