### PR TITLE
Error handling on non RFC 2616 compliant 'Expires' header

### DIFF
--- a/lib/faraday/http_cache/response.rb
+++ b/lib/faraday/http_cache/response.rb
@@ -173,9 +173,9 @@ module Faraday
 
       # Internal: Gets the 'Expires' in a Time object.
       #
-      # Returns the Time object, or nil if the header isn't present.
+      # Returns the Time object, or nil if the header isn't present or isn't RFC 2616 compliant.
       def expires
-        headers['Expires'] && Time.httpdate(headers['Expires'])
+        @expires ||= headers['Expires'] && Time.httpdate(headers['Expires']) rescue nil
       end
 
       # Internal: Gets the 'CacheControl' object.

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -130,6 +130,12 @@ describe Faraday::HttpCache::Response do
       response = Faraday::HttpCache::Response.new
       expect(response.max_age).to be_nil
     end
+
+    it 'returns nil when falling back to expiration date but it is not RFC 2616 compliant' do
+      headers = { 'Expires' => 'Mon, 1 Jan 2001 00:00:00 GMT' }
+      response = Faraday::HttpCache::Response.new(response_headers: headers)
+      expect(response.max_age).to be_nil
+    end
   end
 
   describe 'age calculation' do


### PR DESCRIPTION
I encountered this issue myself and I'd like to resolve #68 with this simple commit.
I also stored the expiration date in the @expires instance variable.