### PR TITLE
Fix a couple of warnings in the test suite

### DIFF
--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -9,6 +9,7 @@ describe Faraday::HttpCache do
       stack.use Faraday::HttpCache, options
       adapter = ENV['FARADAY_ADAPTER']
       stack.headers['X-Faraday-Adapter'] = adapter
+      stack.headers['Content-Type'] = 'application/x-www-form-urlencoded'
       stack.adapter adapter.to_sym
     end
   end

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -52,7 +52,9 @@ describe Faraday::HttpCache::Storage do
           logger = double(:logger, warn: nil)
           storage = Faraday::HttpCache::Storage.new(logger: logger)
 
-          expect { storage.write(request, response) }.to raise_error
+          expect {
+            storage.write(request, response)
+          }.to raise_error(Encoding::UndefinedConversionError)
           expect(logger).to have_received(:warn).with(
             'Response could not be serialized: "\xE2" from ASCII-8BIT to UTF-8. Try using Marshal to serialize.'
           )


### PR DESCRIPTION
The following warnings are being showing when the test suite is run:
```
net/http: warning: Content-Type did not set; using
application/x-www-form-urlencoded
```
```
WARNING: Using the `raise_error` matcher without providing a specific
error or message
```
This commit fixes both issues