### PR TITLE
Document that cache stores MUST respond to #delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ end
 ```
 
 The middleware accepts a `store` option for the cache backend responsible for recording
-the API responses that should be stored. Stores should respond to `write` and `read`,
+the API responses that should be stored. Stores should respond to `write`, `read` and `delete`,
 just like an object from the `ActiveSupport::Cache` API.
 
 ```ruby


### PR DESCRIPTION
Quick README addition: the current README says that cache stores must implement `#read`, and `#write`, but the `Storage` class also expects `#delete`. [Here](https://github.com/plataformatec/faraday-http-cache/blob/master/lib/faraday/http_cache/storage.rb#L162).

This bit me while running some tests against a custom cache store.