### PR TITLE
store option support storage instance

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -172,7 +172,7 @@ module Faraday
     #
     # Returns a Storage instance.
     def create_storage(options)
-      Storage.new(options)
+      options[:store].is_a?(Storage) ? options[:store] : Storage.new(options)
     end
 
     private

--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -8,13 +8,14 @@ module Faraday
     # Examples
     #
     #   # Creates a new Storage using a MemCached backend from ActiveSupport.
-    #   Faraday::HttpCache::Storage.new(:mem_cache_store)
+    #   mem_cache_store = ActiveSupport::Cache.lookup_store(:mem_cache_store, ['localhost:11211'])
+    #   Faraday::HttpCache::Storage.new(store: mem_cache_store)
     #
     #   # Reuse some other instance of an ActiveSupport::Cache::Store object.
-    #   Faraday::HttpCache::Storage.new(Rails.cache)
+    #   Faraday::HttpCache::Storage.new(store: Rails.cache)
     #
     #   # Creates a new Storage using Marshal for serialization.
-    #   Faraday::HttpCache::Storage.new(:memory_store, serializer: Marshal)
+    #   Faraday::HttpCache::Storage.new(store: Rails.cache, serializer: Marshal)
     class Storage
       # Public: Gets the underlying cache store object.
       attr_reader :cache

--- a/spec/http_cache_option_store_spec.rb
+++ b/spec/http_cache_option_store_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Faraday::HttpCache do
+
+  let(:app) { double('it is an app!') }
+
+  it 'when options[:store] is nil' do
+    http_cache = Faraday::HttpCache.new(app, {})
+
+    expect(http_cache.instance_variable_get(:@storage)).to be_a(Faraday::HttpCache::Storage)
+  end
+
+  it 'when options[:store] is not nil and not a Storage instance' do
+    store = double(read: nil, write: nil, delete: nil)
+    http_cache = Faraday::HttpCache.new(app, {store: store})
+
+    expect(http_cache.instance_variable_get(:@storage)).to be_a(Faraday::HttpCache::Storage)
+  end
+
+  it 'when options[:store] is a Storage instance' do
+    store = Faraday::HttpCache::Storage.new
+    http_cache = Faraday::HttpCache.new(app, {store: store})
+
+    expect(http_cache.instance_variable_get(:@storage)).to be_a(Faraday::HttpCache::Storage)
+  end
+
+end


### PR DESCRIPTION
Hi

Some times, we request url is like `http://example.com/users/3?access_token=xxxxxx`, and we want cache it. Now, The default cache_key is the full url(include ?access_token=xxxxxx).

So, I make a subclass for Storage, and override cache_key_for method, and use it like this
```ruby
module Faraday
  class HttpCache
    class MyStorage < Storage
      def cache_key_for(url)
        uri = URI.parse(url.to_s)
        params = Rack::Utils.parse_query(uri.query)
        params = params.except('access_token')
        uri.query = params.to_query

        super uri
      end
    end
  end
end

store = Faraday::HttpCache::MyStorage.new(store: Rails.cache)

client = Faraday.new do |builder|
  builder.use :http_cache, store: store
  builder.adapter Faraday.default_adapter
end
```

But it does not working.

So, I make a PR to solve it.

Please review it. thanks.

