### PR TITLE
Added error checking for invalid Date response header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'faraday_middleware', '>= 0.9.1'
-gem 'activesupport',      '>= 3.0'
+gem 'activesupport',      '~> 4.2'
 gem 'em-http-request',    '~> 1.1'
 gem 'sinatra',            '~> 1.4'
 gem 'rspec',              '~> 3.1'

--- a/gemfiles/Gemfile.faraday-0.8
+++ b/gemfiles/Gemfile.faraday-0.8
@@ -5,7 +5,7 @@ gem 'faraday-http-cache', path: '..'
 gem 'faraday',            '0.8.9'
 gem 'faraday_middleware', '0.9.0'
 
-gem 'activesupport',      '>= 3.0'
+gem 'activesupport',      '~> 4.2'
 gem 'em-http-request',    '~> 1.1'
 gem 'sinatra',            '~> 1.4'
 gem 'rspec',              '~> 3.1'

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -207,6 +207,8 @@ module Faraday
 
       return fetch(env) if entry.nil?
 
+      @logger.debug("cached response_headers = #{entry.payload[:response_headers]}") if @logger
+
       if entry.fresh?
         response = entry.to_response(env)
         trace :fresh
@@ -302,6 +304,7 @@ module Faraday
       trace :miss
       @app.call(env).on_complete do |fresh_env|
         response = Response.new(create_response(fresh_env))
+        @logger.debug("fetched response_headers = #{response.payload[:response_headers]}") if @logger
         store(response)
       end
     end

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -207,8 +207,6 @@ module Faraday
 
       return fetch(env) if entry.nil?
 
-      @logger.debug("cached response_headers = #{entry.payload[:response_headers]}") if @logger
-
       if entry.fresh?
         response = entry.to_response(env)
         trace :fresh
@@ -304,7 +302,6 @@ module Faraday
       trace :miss
       @app.call(env).on_complete do |fresh_env|
         response = Response.new(create_response(fresh_env))
-        @logger.debug("fetched response_headers = #{response.payload[:response_headers]}") if @logger
         store(response)
       end
     end

--- a/lib/faraday/http_cache/response.rb
+++ b/lib/faraday/http_cache/response.rb
@@ -38,7 +38,11 @@ module Faraday
         @now = Time.now
         @payload = payload
         wrap_headers!
-        headers['Date'] ||= @now.httpdate
+        begin
+          date
+        rescue
+          headers['Date'] = @now.httpdate
+        end
 
         @last_modified = headers['Last-Modified']
         @etag = headers['ETag']
@@ -192,10 +196,10 @@ module Faraday
       #
       # Returns nothing.
       def wrap_headers!
-        headers = @payload[:response_headers]
+        headers_hash = @payload[:response_headers]
 
         @payload[:response_headers] = Faraday::Utils::Headers.new
-        @payload[:response_headers].update(headers) if headers
+        @payload[:response_headers].update(headers_hash) if headers_hash
       end
 
       # Internal: Gets the headers 'Hash' from the payload.

--- a/lib/faraday/http_cache/response.rb
+++ b/lib/faraday/http_cache/response.rb
@@ -38,11 +38,7 @@ module Faraday
         @now = Time.now
         @payload = payload
         wrap_headers!
-        begin
-          date
-        rescue
-          headers['Date'] = @now.httpdate
-        end
+        ensure_date_header!
 
         @last_modified = headers['Last-Modified']
         @etag = headers['ETag']
@@ -196,10 +192,21 @@ module Faraday
       #
       # Returns nothing.
       def wrap_headers!
-        headers_hash = @payload[:response_headers]
+        headers = @payload[:response_headers]
 
         @payload[:response_headers] = Faraday::Utils::Headers.new
-        @payload[:response_headers].update(headers_hash) if headers_hash
+        @payload[:response_headers].update(headers) if headers
+      end
+
+      # Internal: Try to parse the Date header, if it fails set it to @now.
+      #
+      # Returns nothing.
+      def ensure_date_header!
+        begin
+          date
+        rescue
+          headers['Date'] = @now.httpdate
+        end
       end
 
       # Internal: Gets the headers 'Hash' from the payload.

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -96,6 +96,14 @@ describe Faraday::HttpCache::Response do
     expect(response.date).to be
   end
 
+  it 'sets the "Date" header if is not a valid RFC 2616 compliant string' do
+    date = Time.now.httpdate
+    headers = { 'Date' => "#{date}, #{date}" }
+    response = Faraday::HttpCache::Response.new(response_headers: headers)
+
+    expect(response.date).to be
+  end
+
   it 'the response is not modified if the status code is 304' do
     response = Faraday::HttpCache::Response.new(status: 304)
     expect(response).to be_not_modified


### PR DESCRIPTION
and more logging for fetched/cached response headers.

I've encountered a site where the 'Date' response header was corrupted (it had the Date string duplicated/joined with a comma: e.g. "Thu, 11 Aug 2016 04:58:24 GMT, Thu, 11 Aug 2016 04:58:24 GMT"). Though this should be a rare case, this commit prevents the response from throwing a "not RFC 2616 compliant date" error when the 'Date' header is invalid.