### PR TITLE
Spec: Load ActiveSupport Notifications before use

### DIFF
--- a/spec/instrumentation_spec.rb
+++ b/spec/instrumentation_spec.rb
@@ -13,7 +13,7 @@ describe 'Instrumentation' do
   end
 
   let(:events) { [] }
-  let(:subscriber) { lambda { |*args| events << ActiveSupport::Notifications::Event.new(*
+  let(:subscriber) { lambda { |*args| events << ActiveSupport::Notifications::Event.new(*args) } }
     
   around do |example|
     ActiveSupport::Notifications.subscribed(subscriber, 'http_cache.faraday') do

--- a/spec/instrumentation_spec.rb
+++ b/spec/instrumentation_spec.rb
@@ -13,6 +13,11 @@ describe 'Instrumentation' do
   let(:events) { [] }
   let(:subscriber) { lambda { |*args| events << ActiveSupport::Notifications::Event.new(*args) } }
 
+  before :all do
+    require 'active_support'
+    require 'active_support/notifications'
+  end
+    
   around do |example|
     ActiveSupport::Notifications.subscribed(subscriber, 'http_cache.faraday') do
       example.run

--- a/spec/instrumentation_spec.rb
+++ b/spec/instrumentation_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'active_support'
+require 'active_support/notifications'
 
 describe 'Instrumentation' do
   let(:backend) { Faraday::Adapter::Test::Stubs.new }
@@ -11,12 +13,7 @@ describe 'Instrumentation' do
   end
 
   let(:events) { [] }
-  let(:subscriber) { lambda { |*args| events << ActiveSupport::Notifications::Event.new(*args) } }
-
-  before :all do
-    require 'active_support'
-    require 'active_support/notifications'
-  end
+  let(:subscriber) { lambda { |*args| events << ActiveSupport::Notifications::Event.new(*
     
   around do |example|
     ActiveSupport::Notifications.subscribed(subscriber, 'http_cache.faraday') do

--- a/spec/instrumentation_spec.rb
+++ b/spec/instrumentation_spec.rb
@@ -14,7 +14,7 @@ describe 'Instrumentation' do
 
   let(:events) { [] }
   let(:subscriber) { lambda { |*args| events << ActiveSupport::Notifications::Event.new(*args) } }
-    
+
   around do |example|
     ActiveSupport::Notifications.subscribed(subscriber, 'http_cache.faraday') do
       example.run


### PR DESCRIPTION
This PR adds a `require` to one of the specs, so that it can pass when run via rake, too.

With this change, this suite passes in Rake, too. Without it, the suite failed becuase that file had 4 test failures on not having loaded the Notifications constant.

With this change, you could change the Travis build to use the default `script` task instead of the `bin/rspec` one.