### PR TITLE
Fix exception namespacing conflict with Faraday::Encoding

### DIFF
--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -56,7 +56,7 @@ module Faraday
         entries << entry
 
         cache.write(key, entries)
-      rescue Encoding::UndefinedConversionError => e
+      rescue ::Encoding::UndefinedConversionError => e
         warn "Response could not be serialized: #{e.message}. Try using Marshal to serialize."
         raise e
       end

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -55,7 +55,7 @@ describe Faraday::HttpCache::Storage do
 
           expect {
             storage.write(request, response)
-          }.to raise_error(Encoding::UndefinedConversionError)
+          }.to raise_error(::Encoding::UndefinedConversionError)
           expect(logger).to have_received(:warn).with(
             'Response could not be serialized: "\xE2" from ASCII-8BIT to UTF-8. Try using Marshal to serialize.'
           )


### PR DESCRIPTION
It turns out that if you have https://github.com/ma2gedev/faraday-encoding loaded alongside `faraday-http-cache`, there is a namespace conflict in `Faraday::HttpCache::Storage#write`. In short, this happens:

```
NameError: uninitialized constant Faraday::Encoding::UndefinedConversionError
from /app/vendor/bundle/ruby/2.3.0/gems/faraday-http-cache-2.0.0/lib/faraday/http_cache/storage.rb:59:in `rescue in write'
```

Because `Encoding::UndefinedConversionError` is not scoped globally, Ruby thinks it should exist in `Faraday::Encoding`. Not only is this not the desired behavior, but it has the really nasty effect of hiding other exceptions that occur in that method, as the `NameError` happens when it tries to execute the `rescue` block.

Luckily it's a simple fix; just namespace the exception absolutely. 😄 