### PR TITLE
Fix compatibility with MessagePack serializer

### DIFF
--- a/lib/faraday/http_cache/request.rb
+++ b/lib/faraday/http_cache/request.rb
@@ -39,7 +39,7 @@ module Faraday
       def serializable_hash
         {
           method: @method,
-          url: @url,
+          url: @url.to_s,
           headers: @headers
         }
       end


### PR DESCRIPTION
Request url is an instance of URI::HTTP which is unsupported for
dumping by MessagePack.

Based on JSON serialising behavior I expect that it's safe to
convert URI::HTTP to String before dumping:

```ruby
  >> URI('http://github.com').to_json
  => "\"http://github.com\""
```