### PR TITLE
Travis: update Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 env:
   - FARADAY_ADAPTER=net_http
   - FARADAY_ADAPTER=em_http


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.