### PR TITLE
Add cache key configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ end
 client.get('http://site/api/some-private-resource') # => will be cached
 ```
 
+### Custom cache key
+
+By default, the middleware uses the url from the `request` object as a cache key. In the event that
+you might want to pass a key that uses different values from the `request`, you can use the
+`:cache_key_callback` configuration option. This option takes a `Proc` that receives the `request`
+object as an argument:
+
+```ruby
+client = Faraday.new do |builder|
+  builder.use :http_cache,
+              cache_key_callback: -> (request) do
+                "#{request.headers['Authorization'].match(/\Atoken\s(.*)\z/)[1]}/#{request.url}"
+              end
+  builder.adapter Faraday.default_adapter
+end
+
+client.get do |req|
+  req.url 'http://site/api/some-resource'
+  req.headers['Authorization'] = 'token 1234'
+end
+# => cache_key will be a Digest::SHA1.hexdigest value of '1234/http://site/api/some-resource'
+```
+
 ## License
 
 Copyright (c) 2012-2014 Plataformatec. See LICENSE file.

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -99,14 +99,14 @@ module Faraday
     #   # Initialize the middleware with a MemoryStore and logger
     #   store = ActiveSupport::Cache.lookup_store
     #   Faraday::HttpCache.new(app, store: store, logger: my_logger)
-    def initialize(app, store: nil, serializer: nil, shared_cache: true, instrumenter: nil, instrument_name: EVENT_NAME, logger: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(app, store: nil, serializer: nil, shared_cache: true, instrumenter: nil, instrument_name: EVENT_NAME, logger: nil, cache_key_callback: nil) # rubocop:disable Metrics/ParameterLists
       super(app)
 
       @logger = logger
       @shared_cache = shared_cache
       @instrumenter = instrumenter
       @instrument_name = instrument_name
-      @storage = Storage.new(store: store, serializer: serializer, logger: logger)
+      @storage = Storage.new(store: store, serializer: serializer, logger: logger, cache_key_callback: cache_key_callback)
     end
 
     # Public: Process the request into a duplicate of this instance to

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -147,7 +147,7 @@ module Faraday
       end
 
       response.on_complete do
-        delete(@request, response) if should_delete?(response.status, @request.method)
+        delete(@request) if should_delete?(response.status, @request.method)
         log_request
         response.env[:http_cache_trace] = @trace
         instrument(response.env)
@@ -269,14 +269,13 @@ module Faraday
       end
     end
 
-    def delete(request, response)
-      headers = %w(Location Content-Location)
-      headers.each do |header|
-        url = response.headers[header]
-        @storage.delete(url) if url
-      end
-
-      @storage.delete(request.url)
+    # Internal: Deletes the cache entry in the store.
+    #
+    # request - a 'Faraday::HttpCache::Request' instance.
+    #
+    # Returns nothing.
+    def delete(request)
+      @storage.delete(request)
       trace :delete
     end
 

--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -80,8 +80,8 @@ module Faraday
         end
       end
 
-      def delete(url)
-        cache_key = cache_key_for(url)
+      def delete(request)
+        cache_key = cache_key_for(request)
         cache.delete(cache_key)
       end
 

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -94,18 +94,6 @@ describe Faraday::HttpCache do
       expect(logger).to receive(:debug) { |&block| expect(block.call).to eq('HTTP Cache: [GET /broken] miss, uncacheable') }
       client.get('broken')
     end
-
-    it 'expires entries for the "Location" header' do
-      client.get('get')
-      client.post('delete-with-location')
-      expect(client.get('get').body).to eq('2')
-    end
-
-    it 'expires entries for the "Content-Location" header' do
-      client.get('get')
-      client.post('delete-with-content-location')
-      expect(client.get('get').body).to eq('2')
-    end
   end
 
   describe 'when acting as a shared cache' do
@@ -292,6 +280,15 @@ describe Faraday::HttpCache do
 
       expect(Faraday::HttpCache::Storage).to receive(:new).with(hash_including(store: store))
       Faraday::HttpCache.new(app, store: store)
+    end
+
+    describe 'when cache_key_callback option is provided' do
+      cache_key_callback = -> { 'my custom cache key callback' }
+
+      it 'uses the cache_key_callback option' do
+        expect(Faraday::HttpCache::Storage).to receive(:new).with(hash_including(cache_key_callback: cache_key_callback))
+        Faraday::HttpCache.new(app, cache_key_callback: cache_key_callback)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a proposal to add a new configuration option called `:cache_key_callback` which allows customization of the `cache_key` by passing a `Proc` that takes the `request` object as an argument.

I've added an example to the `README` for clarity.

It seems that in the past, the entire `request` object was passed to the private `#cache_key_for` method but was amended to pass only the `request.url` due to issues with cache invalidation which was brought up here: https://github.com/plataformatec/faraday-http-cache/issues/42

Because the `request.url` is the only attribute ever used as a `cache_key` I was wondering if the code [here](https://github.com/plataformatec/faraday-http-cache/compare/master...ryuichi7:configurable_cache_key?expand=1#diff-d2d5f6accffbb073ba748af2ca6f8598L273
) is necessary? I couldn't find any place where the `Location` or `Content-Location` header values are used as a `cache_key`. That's why I removed it, but maybe I'm missing something?

Thanks so much!