### PR TITLE
Cache fresh responses even if they have 'must-revalidate'

### DIFF
--- a/lib/faraday/http_cache/response.rb
+++ b/lib/faraday/http_cache/response.rb
@@ -50,7 +50,7 @@ module Faraday
       #
       # Returns true if the response is fresh, otherwise false.
       def fresh?
-        !cache_control.must_revalidate? && !cache_control.no_cache? && ttl && ttl > 0
+        !cache_control.no_cache? && ttl && ttl > 0
       end
 
       # Internal: Checks if the Response returned a 'Not Modified' status.

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -274,6 +274,11 @@ describe Faraday::HttpCache do
     expect(first_vary).not_to eql(second_vary)
   end
 
+  it 'caches non-stale response with "must-revalidate" directive' do
+    client.get('must-revalidate')
+    expect(client.get('must-revalidate').body).to eq('1')
+  end
+
   it 'raises an error when misconfigured' do
     expect {
       client = Faraday.new(url: ENV['FARADAY_SERVER']) do |stack|

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -89,8 +89,16 @@ describe Faraday::HttpCache::Response do
       expect(response).not_to be_fresh
     end
 
-    it 'is not fresh if Cache Control has "must-revalidate"' do
+    it 'is fresh if the response contains "must-revalidate" and is not stale' do
       date = (Time.now - 200).httpdate
+      headers = { 'Cache-Control' => 'public, max-age=23880, must-revalidate, no-transform', 'Date' => date }
+      response = Faraday::HttpCache::Response.new(response_headers: headers)
+
+      expect(response).to be_fresh
+    end
+
+    it 'is not fresh if Cache Control has "must-revalidate" and is stale' do
+      date = (Time.now - 500).httpdate
       headers = { 'Cache-Control' => 'max-age=400, must-revalidate', 'Date' => date }
       response = Faraday::HttpCache::Response.new(response_headers: headers)
 

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -88,6 +88,10 @@ class TestApp < Sinatra::Base
     [200, { 'Date' => settings.yesterday, 'Expires' => settings.yesterday }, increment_counter]
   end
 
+  get '/must-revalidate' do
+    [200, { 'Date' => Time.now.httpdate, 'Cache-Control' => 'public, max-age=23880, must-revalidate, no-transform' }, increment_counter]
+  end
+
   get '/timestamped' do
     settings.counter += 1
     header = settings.counter > 2 ? '1' : '2'


### PR DESCRIPTION
My take on #100.

This may be naive and/or missing something, but I wanted to open the discussion with this PR.