### PR TITLE
CI: Drop unused Travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 script: bin/rspec
-sudo: false
 cache: bundler
 rvm:
   - 2.4


### PR DESCRIPTION
Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration