### PR TITLE
Gemfile: use https for RubyGems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
This PR changes the Gemfile to point to **https** for RubyGems.org.