### PR TITLE
Revalidate rather than entirely discard the cached entry when the client set Cache-Control: no-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ InstalledFiles
 _yardoc
 coverage
 doc/
+log/
 lib/bundler/man
 pkg
 rdoc


### PR DESCRIPTION
[RFC-7234 5.2.1.4.  no-cache](https://tools.ietf.org/html/rfc7234#section-5.2.1.4)

   The "no-cache" request directive indicates that a cache MUST NOT use
   a stored response to satisfy the request without successful
   validation on the origin server.

This mean the cached response can be re-used if the server revalidate it.

cc @rafaelfranca @Edouard-Chin