### PR TITLE
Guard against nil response headers in cache invalidation

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -279,10 +279,12 @@ module Faraday
     end
 
     def delete(request, response)
-      headers = %w[Location Content-Location]
-      headers.each do |header|
-        url = response.headers[header]
-        @strategy.delete(url) if url
+      response_headers = response.headers
+      if response_headers
+        %w[Location Content-Location].each do |header|
+          url = response_headers[header]
+          @strategy.delete(url) if url
+        end
       end
 
       @strategy.delete(request.url)

--- a/spec/http_cache_spec.rb
+++ b/spec/http_cache_spec.rb
@@ -107,6 +107,17 @@ describe Faraday::HttpCache do
       client.post('delete-with-content-location')
       expect(client.get('get').body).to eq('2')
     end
+
+    it 'invalidates the request url when the response has no headers' do
+      middleware = Faraday::HttpCache.new(->(env) { env }, logger: logger)
+      middleware.instance_variable_set(:@trace, [])
+      request = double(url: 'http://test/index')
+      response = double(headers: nil)
+      strategy = middleware.instance_variable_get(:@strategy)
+
+      expect(strategy).to receive(:delete).with('http://test/index')
+      expect { middleware.send(:delete, request, response) }.not_to raise_error
+    end
   end
 
   describe 'when acting as a shared cache' do


### PR DESCRIPTION
Fixes #142. When an upstream request fails in a way that yields a response with nil headers (timeout, TCP reset), `delete` raised `NoMethodError: undefined method '[]' for nil` while looking up the Location and Content-Location headers, and that bubbled out of the on_complete callback instead of just invalidating the request url.

This skips the header lookup when headers are nil and still deletes the cache entry for the request url. Added a spec that drives delete with a headerless response.